### PR TITLE
Ajout d'une option pour cocher automatiquement la case Je suis le médecin traitant si c'est le cas

### DIFF
--- a/fse.js
+++ b/fse.js
@@ -1,5 +1,24 @@
 // Tweak the FSE page (Add a button in the FSE page to send the amount to the TPE, implement shortcuts)
 if (window.location.href.startsWith('https://secure.weda.fr/vitalzen/fse.aspx')) {
+
+    chrome.storage.local.get(['TweakFSEDetectMT'], function (result) {
+
+        if (result.TweakFSEDetectMT !== false) {
+
+            lightObserver('vz-medecin-traitant-weda div.mt10.ng-star-inserted', function(element) {
+                let MTDeclare = element[0].innerText;
+                console.log('found MT: ' + MTDeclare);
+                var loggedInUser = document.getElementById('LabelUserLog').innerText;
+                if (MTDeclare.includes(loggedInUser)) {
+                    console.log('MT match');
+                    let select = document.querySelector('vz-orientation select');
+                    select.value = '03'; // Je suis le médecin traitant
+                }
+            });
+            
+        }
+    });
+
     chrome.storage.local.get(['TweakFSECreation'], function (result) {
         if (result.tweakFSEcreation !== false) {
             console.log('fse started');

--- a/options.html
+++ b/options.html
@@ -110,6 +110,7 @@
   <input type="checkbox" id="defaultCotation">  Activer la cotation par défaut dans la FDS. (Nécessite de mettre une cotation favorite nommée "Défaut", et de valider la feuille de soin avec les touches o/n).<br>
   <input type="checkbox" id="TweakFSEGestion"> Activer le rafraichissement automatique des FSE dans la page de télétransmission. (fonctionnalité en beta)<br>
   <input type="checkbox" id="TweakFSECreation"> Active les raccourcis clavier de la création de FSE ainsi que la lecture automatique de la carte vitale.<br>
+  <input type="checkbox" id="TweakFSEDetectMT"> Sélectionne automatiquement l'option "Je suis le médecin traitant" si vous êtes le médecin traitant du patient<br>
   </div>
   <h1>Lien avec Weda-Helper-Companion:</h1>
   <h2>Options de connexion :</h2>

--- a/options.js
+++ b/options.js
@@ -33,6 +33,7 @@ document.addEventListener('DOMContentLoaded', function () {
     'KeyPadPrescription': true,
     'TweakFSEGestion': true,
     'TweakFSECreation': true,
+    'TweakFSEDetectMT' : false,
     'autoSelectPatientCV': true,
     'WarpButtons': true,
     'autoConsentNumPres': false,


### PR DESCRIPTION
J'imagine que la plupart des utilisateurs ont cette case déjà cochée par défaut dans les préférences Weda.
Il s'agit d'un cas d'usage très spécifique, notamment pour les collaborateurs comme moi qui ont par défaut l'option "Médecin traitant de substitution" cochée.