### PR TITLE
Correction d'une typo + enregistrement à l'installation/mise à jour

### DIFF
--- a/background.js
+++ b/background.js
@@ -84,7 +84,10 @@ var defaultSettings = {
   'autoAATI': true,
 };
 
-// Enregistrer les valeurs par défaut dans le stockage
-chrome.storage.local.set({defaultSettings: defaultSettings}, function() {
-  console.log('[background.js] Les valeurs par défaut ont été enregistrées');
+chrome.runtime.onInstalled.addListener((details) => {
+  // Enregistrer les valeurs par défaut dans le stockage
+  chrome.storage.local.set({defaultSettings: defaultSettings}, function() {
+    console.log('[background.js] Les valeurs par défaut ont été enregistrées');
+  });
+
 });

--- a/content.js
+++ b/content.js
@@ -76,8 +76,8 @@ function observeDiseapearance(element, callback, justOnce = false) {
 // // Fonctions de contrôle de l'url et de l'option pour lancer une fonction
 // récupération de la valeur de l'option (donc soit la valeur sauvegardée, soit la valeur par défaut)
 function getOption(optionName, callback) {
-    chrome.storage.local.get([optionName, 'defaultValues'], function(result) {
-        callback(result[optionName] ?? result.defaultValues[optionName]);
+    chrome.storage.local.get([optionName, 'defaultSettings'], function(result) {
+        callback(result[optionName] ?? result.defaultSettings[optionName]);
     });
 }
 


### PR DESCRIPTION
Je corrige une typo qui fait que l'on ne récupérait pas dorrectement les valeurs par défaut
Et une proposition de ne charger les valeurs par défaut qu'à l'installation ou la mise à jour de l'extension pour limiter les requetes