### PR TITLE
Correction de defautDataType

### DIFF
--- a/Consultation.js
+++ b/Consultation.js
@@ -188,10 +188,10 @@ addTweak('https://secure.weda.fr/FolderMedical/ConsultationForm.aspx', 'TweakTab
 
 
     // Ajouter les unités pour les valeurs de suivi
-    getOption(['defautDataType'], function (result) {
+    getOption('defautDataType', function (result) {
         // defautDataType est une liste de valeurs de suivi pour lesquelles les unités doivent être ajoutées
         // il est formaté comme ceci : 'Taille:cm,Poids:kg,Pc:cm,IMC:kg/t²,TAS:mmHg,TAD:mmHg,FC:bpm,Sat:%'
-        let defautDataType = result.defautDataType
+        let defautDataType = result;
         if (defautDataType === undefined) {
             defautDataType = 'TAILLE:cm,Taille:cm,POIDS:kg,Poids:kg,Pc:cm,IMC:p/t²,PAd:mmHg,PAs:mmhg,TAS:mmHg,TAD:mmHg,FC:bpm,Sat:%';
         }


### PR DESCRIPTION
Corrige #121 
Le résultat de getOption n'était pas correctement récupéré et était donc toujours undefined.

Je pense qu'il serait utile de retirer la valeur par défaut de cette partie vu qu'elle est déjà récupérée par getOption.