### PR TITLE
History2left refact + changement injection hotkeys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Toutes les modifications notables de ce projet seront documentées dans ce fichi
 - le focus reste dans le champ de recherche après l'ouverture automatique des prescriptions-types
 - blocage du historyToLeft si une fenêtre de prévisualisation est ouverte pour éviter des superpositions
 - alt+V fonctionne désormais aussi pour valider l'import de documents
+- message [addTweak] plus explicite dans la console
 
 # [2.3] - 2024-05-28
 ## refactory :

--- a/Consultation.js
+++ b/Consultation.js
@@ -1,24 +1,24 @@
 // [Page de Consultation]
 addTweak('https://secure.weda.fr/FolderMedical/ConsultationForm.aspx', 'TweakTabConsultation', function () {
     // Modifier l'ordre de tabulation des valeurs de suivi    
-        function changeTabOrder(elements) {
-            console.log('changeTabOrder started');
-            for (var i = 0; i < elements.length; i++) {
-                elements[i].tabIndex = i + 1;
-            }
+    function changeTabOrder(elements) {
+        console.log('changeTabOrder started');
+        for (var i = 0; i < elements.length; i++) {
+            elements[i].tabIndex = i + 1;
         }
+    }
 
-        lightObserver('[id^="ContentPlaceHolder1_SuivisGrid_EditBoxGridSuiviReponse_"]',changeTabOrder)
-        console.log('ConsultationFormTabOrderer started');
-        // ici aussi les métriques sont difficiles à évaluer. Si on considère environs
-        // 2 éléments par consultation, on peut estimer en gros à 1 clic + 1 drag par consultation
-        recordMetrics({clicks: 1, drags: 1});
+    lightObserver('[id^="ContentPlaceHolder1_SuivisGrid_EditBoxGridSuiviReponse_"]', changeTabOrder)
+    console.log('ConsultationFormTabOrderer started');
+    // ici aussi les métriques sont difficiles à évaluer. Si on considère environs
+    // 2 éléments par consultation, on peut estimer en gros à 1 clic + 1 drag par consultation
+    recordMetrics({ clicks: 1, drags: 1 });
 
 
     // Afficher en overlay une image issue d'une URL en cas de survol de certains éléments
     // Récupérer la liste des éléments présents dans le suivi
     let courbesPossibles = {
-        "Taille-Poids : 3 ans": {"TC": "10", "Question": "Taille", "Genre": "F", "AgeMin": 0, "AgeMax": 2 },
+        "Taille-Poids : 3 ans": { "TC": "10", "Question": "Taille", "Genre": "F", "AgeMin": 0, "AgeMax": 2 },
         "Taille-Poids : 3 ans (M)": { "TC": "11", "Question": "Taille", "Genre": "M", "AgeMin": 0, "AgeMax": 2 },
         "P.crânien : 5 ans": { "TC": "12", "Question": "Pc", "Genre": "F", "AgeMin": 0, "AgeMax": 4 },
         "P.crânien : 5 ans (M)": { "TC": "13", "Question": "Pc", "Genre": "M", "AgeMin": 0, "AgeMax": 4 },
@@ -44,8 +44,8 @@ addTweak('https://secure.weda.fr/FolderMedical/ConsultationForm.aspx', 'TweakTab
     let age = ageCalculated();
 
     // Le genre
-    let gender = document.querySelector('[title="Sexe féminin"]') ? 'F' : 
-                 (document.querySelector('[title="Sexe masculin"]') ? 'M' : undefined);      
+    let gender = document.querySelector('[title="Sexe féminin"]') ? 'F' :
+        (document.querySelector('[title="Sexe masculin"]') ? 'M' : undefined);
     console.log('age and gender', age, gender);
 
     // épurer courbesPossibles pour ne garder que les lignes pertinentes selon l'age et le genre
@@ -103,11 +103,11 @@ addTweak('https://secure.weda.fr/FolderMedical/ConsultationForm.aspx', 'TweakTab
             let explanationText = document.createElement('p');
             explanationText.innerHTML = 'Courbes Pédiatrique affichée via Weda-Helper :<br>- Pour obtenir une courbe avec les valeurs du jour faites ctrl+S avant affichage ou cliquez sur le bouton Enregistrer en haut à gauche.<br>- Cliquez sur l\'icone courbe pour maintenir l\'affichage.<br>- Imprimez avec ctrl+P.<br>- Aller dans les Options pour désactiver ce message<br>';
             explanationText.style.marginTop = '200px'; // éviter que le message soit tout en haut
-            explanationText.style.maxWidth = '15em';        
+            explanationText.style.maxWidth = '15em';
             return explanationText;
         }
-        
-        
+
+
         function addHoverElement(element, key) {
             let tooltip = createTooltip(key);
             let img = createImage(key);
@@ -117,13 +117,13 @@ addTweak('https://secure.weda.fr/FolderMedical/ConsultationForm.aspx', 'TweakTab
             tooltip.appendChild(img);
             element.appendChild(tooltip);
 
-            element.addEventListener('mouseover', function() {
+            element.addEventListener('mouseover', function () {
                 let imageUrl = urlImage(key);
                 let pdfUrl = urlImage(key) + '&Pdf=True';
                 // ajouter le pdfUrl comme information dans l'élément img
                 img.setAttribute('data-pdf-url', pdfUrl);
                 img.src = imageUrl;
-                img.onload = function() {
+                img.onload = function () {
                     loadingText.style.display = 'none';
                     img.style.display = 'block';
                     tooltip.appendChild(explanationText);
@@ -137,7 +137,7 @@ addTweak('https://secure.weda.fr/FolderMedical/ConsultationForm.aspx', 'TweakTab
             }
 
             // Ne pas cacher l'info-bulle lorsque la souris quitte l'élément si l'élément a été cliqué
-            element.addEventListener('mouseout', function() {
+            element.addEventListener('mouseout', function () {
                 if (!element.clicked) {
                     toolTipOff();
                 } else if (tooltip.style.display === 'none') {
@@ -146,7 +146,7 @@ addTweak('https://secure.weda.fr/FolderMedical/ConsultationForm.aspx', 'TweakTab
             });
 
             // Ne pas cacher l'info-bulle lors du clic sur l'élément, ou la cacher si elle est déjà visible
-            element.addEventListener('click', function(event) {
+            element.addEventListener('click', function (event) {
                 if (element.clicked) {
                     element.clicked = false;
                     toolTipOff();
@@ -157,7 +157,7 @@ addTweak('https://secure.weda.fr/FolderMedical/ConsultationForm.aspx', 'TweakTab
             });
 
             // Cacher l'info-bulle lors du clic sur l'image
-            img.addEventListener('click', function(event) {
+            img.addEventListener('click', function (event) {
                 element.clicked = false;
                 toolTipOff();
             });
@@ -167,7 +167,7 @@ addTweak('https://secure.weda.fr/FolderMedical/ConsultationForm.aspx', 'TweakTab
             let patDk = url.split('PatDk=')[1].split('&')[0];
             let tc = courbesPossiblesFiltered[key].TC;
             // pour la métrique je considère que dès que l'url est appelée c'est une action
-            recordMetrics({clicks: 4, drags: 4});
+            recordMetrics({ clicks: 4, drags: 4 });
             return `https://secure.weda.fr/CourbeWEDA.aspx?PatDk=${patDk}&TC=${tc}`;
         }
 
@@ -183,7 +183,7 @@ addTweak('https://secure.weda.fr/FolderMedical/ConsultationForm.aspx', 'TweakTab
             }
         });
     }
-    
+
     lightObserver('#ContentPlaceHolder1_SuivisGrid_LabelGridSuiviQuestion_0', addOverIcon);
 
 
@@ -212,7 +212,7 @@ addTweak('https://secure.weda.fr/FolderMedical/ConsultationForm.aspx', 'TweakTab
         });
         // un peu compliqué de mettre des metrics ici... car les utilisateurs ne mettent en général simplement pas d'unité
     });
-        
+
 });
 
 
@@ -253,221 +253,81 @@ let pagesToLeftPannel_ = [
 ]
 
 
-// à intégrer après le addTweak
-// Étape 1 : Récupérer les paramètres de l'URL actuelle
-function getUrlParams() {
-    let url = window.location.href;
-    let params = url.split('?')[1];
-    return params; // Retourne la chaîne de requête
+const SELECTORS_TO_REMOVE = [
+    '#PanelFiltre',
+    '.fondcoordination',
+    '[name="dh9"]',
+    '.frameupright',
+    '.frameupleft',
+    '.frameupcenter',
+    '#HistoriqueUCForm1_PanelInfoFlottante',
+];
+const HISTORY_PROPORTION = 0.29;
+
+function getUrlHistory() {
+    const url = window.location.href;
+    const params = url.split('?')[1];
+    return `https://secure.weda.fr/FolderMedical/FrameHistoriqueForm.aspx?${params}`;
 }
 
-// Étape 2 : Créer une nouvelle iframe
 function createIframe() {
-    let iframe = document.createElement('iframe');
-    iframe.style.width = "100%";
-    iframe.style.height = "600px"; // Ajuster selon les besoins
+    const iframe = document.createElement('iframe');
+    iframe.style.width = `${window.innerWidth * HISTORY_PROPORTION}px`;
+    iframe.style.height = "600px";
+    iframe.src = getUrlHistory();
+    document.body.appendChild(iframe);
     return iframe;
 }
 
-// Étape 3 : Configurer l'URL de la nouvelle iframe
-function setIframeSrc(iframe, baseUrl, queryParams) {
-    iframe.src = `${baseUrl}?${queryParams}`;
+function removeElements(iframeDocument) {
+    SELECTORS_TO_REMOVE.forEach(selector => {
+        const elements = iframeDocument.querySelectorAll(selector);
+        elements.forEach(element => element.remove());
+    });
 }
 
-// Faire un loop sur le tableau
+function adjustLayout(pageType, iframe, targetElement) {
+    const availableWidth = window.innerWidth;
+    const targetElementWidth = (1 - HISTORY_PROPORTION - 0.01) * availableWidth;
+    targetElement.style.position = 'absolute';
+    targetElement.style.left = `${iframe.getBoundingClientRect().right}px`;
+    targetElement.style.marginTop = '0px';
+    targetElement.style.width = `${targetElementWidth}px`;
+
+    if (["Certificat", "Demande", "Courrier"].includes(pageType)) {
+        const adjustmentTable = {
+            "Certificat": { 1500: 0.85, 1700: 0.9, 2000: 0.95, 5000: 1 },
+            "Demande": { 1300: 0.7, 1700: 0.8, 2000: 0.9, 2500: 1 },
+            "Courrier": { 1500: 0.75, 1700: 0.85, 1900: 0.9, 2100: 0.95, 5000: 1 }
+        };
+        const adjustement = getAdjustment(availableWidth, adjustmentTable[pageType]);
+        const textAreaWidth = (1 - HISTORY_PROPORTION) * (availableWidth * adjustement) * 0.8;
+        targetElement.style.width = `${textAreaWidth}px`;
+    }
+}
+
+function getAdjustment(availableWidth, adjustmentTable) {
+    const keys = Object.keys(adjustmentTable).sort((a, b) => a - b);
+    const adjustementKey = keys.find(key => availableWidth <= key);
+    return adjustmentTable[adjustementKey] || adjustmentTable[keys[keys.length - 1]];
+}
+
 pagesToLeftPannel_.forEach(page => {
-    addTweak(page.url, page.option, function() {
-        let pageType = page.pageType;
-        
-        console.log('MoveHistoriqueToLeft démarré');
-        function moveToLeft(iframes) {
-            function warpHistory(elementToShrink) {
-                // Redimensionner l'affichage de l'historique
-                let margin = (elementToMove.getBoundingClientRect().width - 70);
-                if (elementToShrink) {
-                    elementToShrink.style.maxWidth = margin + 'px';
-                }
-            }
+    addTweak(page.url, page.option, () => {
+        const iframe = createIframe();
+        iframe.addEventListener('load', () => {
+            removeElements(iframe.contentDocument);
+        });
 
-
-            function warpElements() {
-                let historyProportion = 0.3;
-                let availableWidth = window.innerWidth;
-                let elementToMoveWidth = availableWidth * historyProportion;
-                let targetElementWidth = (1 - historyProportion) * availableWidth;
-                
-                // Bouger l'historique à gauche et le redimensionner
-                elementToMove.style.position = 'absolute';
-                elementToMove.style.left = '0px';
-                elementToMove.style.marginTop = '0px'; // Remove top margin
-                elementToMove.style.width = elementToMoveWidth + 'px'; 
-
-                // Stocker les valeurs initiales
-                initialStylesTargetElement = {
-                    position: targetElement.style.position,
-                    left: targetElement.style.left,
-                    marginTop: targetElement.style.marginTop,
-                    width: targetElement.style.width
-                };
-
-                // Bouger la cible à droite et la redimensionner
-                targetElement.style.position = 'absolute';
-                targetElement.style.left = (elementToMove.getBoundingClientRect().right) + 'px';
-                targetElement.style.marginTop = '0px'; // Remove top margin
-                console.log('availableWidth', availableWidth);
-                
-
-                if (pageType === "Consultation") {
-                    targetElement.style.width = targetElementWidth + 'px';
-                    let unitsElementWidth = (1 - historyProportion) * availableWidth * 0.2;
-
-                    initialStylesUnitsElement = {
-                        position: unitsElement.style.position,
-                        left: unitsElement.style.left,
-                        marginTop: unitsElement.style.marginTop,
-                        width: unitsElement.style.width
-                    };
-
-                    // Modifier la largeur de l'élément de suivi
-                    unitsElement.style.width = unitsElementWidth + 'px';
-                } else if (pageType === "Formulaire") {
-                    targetElement.style.width = targetElementWidth + 'px';
-
-                } else if (pageType === "Certificat" || pageType === "Demande" || pageType === "Courrier") {
-                    // modifier la taille du cadre contenant la selection de documents type
-                    let documentTypeWidth = (1 - historyProportion) * availableWidth * 0.2;
-                    toSetRight.setAttribute("align", "right");
-                    console.log('toSetFifty', toSetFifty);
-                    toSetFifty.setAttribute("width", documentTypeWidth + "px");
-
-                    // modifier la taille du cadre contenant la zone de texte (l'équivalent de targetElement sur la page de consultation)
-                    if (pageType === "Certificat") {
-                        var adjustementTable = {1500: 0.85, 1700: 0.9, 2000: 0.95, 5000:1};
-                    } else if (pageType === "Demande") {
-                        var adjustementTable = {1300: 0.7, 1700: 0.8, 2000: 0.9, 2500: 1};
-                    } else if (pageType === "Courrier") {
-                        var adjustementTable = {1500: 0.75, 1700: 0.85, 1900: 0.9, 2100: 0.95, 5000: 1};
-                    }
-                    let keys = Object.keys(adjustementTable).sort((a, b) => a - b);
-                    let adjustementKey = keys.find(key => availableWidth <= key);
-                    let adjustement = adjustementTable[adjustementKey] || adjustementTable[keys[keys.length - 1]];
-                    console.log('adjustement', adjustement);
-                    let textAreaWidth = (1 - historyProportion) * (availableWidth * adjustement) * 0.8;
-                    targetElement.style.width = textAreaWidth + 'px';
-
-                    // put #ContentPlaceHolder1_DocVersionUserControl_PanelPrescriptionDmp and its children to the background
-                    let prescriptionDmp = document.querySelector('#ContentPlaceHolder1_DocVersionUserControl_PanelPrescriptionDmp');
-                    if (prescriptionDmp) {
-                        prescriptionDmp.style.position = 'relative'; // z-index only works on positioned elements
-                        prescriptionDmp.style.zIndex = '-1'; // set to a negative value to put it to the background
-                    }
-                }
-
-            }
-
-            function resetTargetElement() {
-                console.log('resetTargetElement');
-                // Rétablir les valeurs initiales
-                targetElement.style.position = initialStylesTargetElement.position;
-                targetElement.style.left = initialStylesTargetElement.left;
-                targetElement.style.marginTop = initialStylesTargetElement.marginTop;
-                targetElement.style.width = initialStylesTargetElement.width;
-
-                if (pageType === "Consultation" || pageType === "Formulaire") {
-                    unitsElement.style.position = initialStylesUnitsElement.position;
-                    unitsElement.style.left = initialStylesUnitsElement.left;
-                    unitsElement.style.marginTop = initialStylesUnitsElement.marginTop;
-                    unitsElement.style.width = initialStylesUnitsElement.width;
-                } else if (pageType === "Certificat" || pageType === "Demande" || pageType === "Courrier") {
-                    toSetFifty.setAttribute("width", '100%');
-                }
-            }
-
-            // Pour éviter de très gênantes superpositions de fenêtres
-            let previewWindow = document.querySelector('#ContentPlaceHolder1_EvenementUcForm1_ViewPdfDocumentUCForm1_PanelViewDocument');
-            if (previewWindow) {
-                return;
-            }
-
-
-            // Définition des éléments à déplacer et de la cible
-            let elementToMove = document.querySelector('#ContentPlaceHolder1_EvenementUcForm1_PanelHistoriqueFrame');
-            let targetElement = document.querySelector(page.targetElementSelector);
-            if (pageType === "Consultation") {
-                var unitsElement = document.querySelector('#ContentPlaceHolder1_SuivisGrid'); // spécifique à la page de consultation
-            } else if (pageType === "Certificat" || pageType === "Demande" || pageType === "Courrier") {
-                var toSetRight = document.querySelector('#ContentPlaceHolder1_UpdatePanelBaseGlossaireUCForm1').parentNode;
-                var toSetFifty = document.querySelector('#ContentPlaceHolder1_UpdatePanelBaseGlossaireUCForm1 table');
-            }
-            let iframeToActOn = iframes[0];
-
-            // liste des selecteurs à suppimer
-            let selectorsToRemove = [
-                '#PanelFiltre',
-                '.fondcoordination',
-                '[name="dh9"]',
-                '.frameupright',
-                '.frameupleft',
-                '.frameupcenter',
-            ];
-
-            warpElements(); // à appeler avant le load de l'iframe pour plus de réactivité
-
-            iframeToActOn.addEventListener('load', () => {
-                let iframeDocument = iframeToActOn.contentDocument;
-
-                // Supprimer les éléments inutiles
-                selectorsToRemove.forEach((selector) => {
-                    lightObserver(selector, (elements) => {
-                        elements.forEach((element) => {
-                            element.remove();
-                        });
-                    }, iframeDocument);
-                });
-
-                setTimeout(() => {
-                    selectorsToRemove.forEach((selector) => {
-                        let element = iframeDocument.querySelector(selector);
-                        if (element) {
-                            element.remove();
-                        }
-                    });
-                }, 20);
-
-                // Redimensionner l'historique
-                let elementToShrink = iframeDocument.querySelector('[style*="max-width:"]');
-                warpHistory(elementToShrink);
-
-                if (pageType === "Consultation") {
-                    let iframeToWriteIn = document.querySelector('#CE_ContentPlaceHolder1_EditorConsultation1_ID_Frame');
-                    iframeToWriteIn.contentDocument.querySelector('body').focus();
-                }
-
-                // réinitialiser les éléments à la disparition de l'iframe
-                observeDiseapearance(iframeToActOn, resetTargetElement, true);
-            });
-        }
-
-
-        // Automatiquement afficher l'historique
-        lightObserver('#ContentPlaceHolder1_EvenementUcForm1_ImageButtonShowHistoriqueFrame', (elements) => {
-            let iframe = document.querySelector('#ContentPlaceHolder1_EvenementUcForm1_PanelHistoriqueFrame > iframe');
-            if (elements.length > 0 && !iframe) {
-                elements[0].click();
-                recordMetrics({clicks: 1, drags: 1});
-            }
-        }, document, true);
-
-
-        // Attendre que l'iframe soit présente ET chargée pour déplacer l'historique
-        lightObserver('#ContentPlaceHolder1_EvenementUcForm1_PanelHistoriqueFrame > iframe', moveToLeft);            
+        const targetElement = document.querySelector(page.targetElementSelector);
+        adjustLayout(page.pageType, iframe, targetElement);
     });
 });
 
 
 // // Afficher les antécédents automatiquement sur les pages où Historique peut être déplacé à gauche (la cible devra peut-être être ajustée)
 pagesToLeftPannel_.forEach((page) => {
-    addTweak(page.url, 'autoATCD', function() {
+    addTweak(page.url, 'autoATCD', function () {
         // Automatiquement afficher l'ATCD
         lightObserver('#ContentPlaceHolder1_EvenementUcForm1_ImageButtonShowAntecedent', () => {
             console.log('[autoATCD] bouton atcd détecté');
@@ -477,9 +337,9 @@ pagesToLeftPannel_.forEach((page) => {
                 let buttonAtcd = document.querySelector('#ContentPlaceHolder1_EvenementUcForm1_ImageButtonShowAntecedent');
                 if (!atcdElement && buttonAtcd) {
                     buttonAtcd.click();
-                    recordMetrics({clicks: 1, drags: 1});
+                    recordMetrics({ clicks: 1, drags: 1 });
                 }
-            });                
-        }, document,true);
+            });
+        }, document, true);
     });
 });

--- a/Consultation.js
+++ b/Consultation.js
@@ -270,12 +270,17 @@ function getUrlHistory() {
     return `https://secure.weda.fr/FolderMedical/FrameHistoriqueForm.aspx?${params}`;
 }
 
-function createIframe() {
+function createIframe(targetElement) {
     const iframe = document.createElement('iframe');
     iframe.style.width = `${window.innerWidth * HISTORY_PROPORTION}px`;
     iframe.style.height = "600px";
     iframe.src = getUrlHistory();
-    document.body.appendChild(iframe);
+    // Injecter l'iframe dans le DOM proche de targetElement pour que ça soit au même niveau
+    // TODO S'assurer que l'iframe soit à gauche de l'écran
+    const parent = targetElement.parentNode;
+    if (parent) {
+        parent.insertBefore(iframe, targetElement.nextSibling); // Insère l'iframe juste après targetElement
+    }
     return iframe;
 }
 
@@ -314,12 +319,13 @@ function getAdjustment(availableWidth, adjustmentTable) {
 
 pagesToLeftPannel_.forEach(page => {
     addTweak(page.url, page.option, () => {
-        const iframe = createIframe();
+        const targetElement = document.querySelector(page.targetElementSelector);
+        const iframe = createIframe(targetElement);
         iframe.addEventListener('load', () => {
             removeElements(iframe.contentDocument);
         });
 
-        const targetElement = document.querySelector(page.targetElementSelector);
+        
         adjustLayout(page.pageType, iframe, targetElement);
     });
 });

--- a/Consultation.js
+++ b/Consultation.js
@@ -363,6 +363,7 @@ pagesToLeftPannel_.forEach(page => {
             removeElements(iframe.contentDocument);
         });
         adjustLayout(page.pageType, iframe, targetElement);
+        recordMetrics({ clicks: 1, drags: 1 });
     });
 });
 

--- a/Consultation.js
+++ b/Consultation.js
@@ -253,6 +253,27 @@ let pagesToLeftPannel_ = [
 ]
 
 
+// à intégrer après le addTweak
+// Étape 1 : Récupérer les paramètres de l'URL actuelle
+function getUrlParams() {
+    let url = window.location.href;
+    let params = url.split('?')[1];
+    return params; // Retourne la chaîne de requête
+}
+
+// Étape 2 : Créer une nouvelle iframe
+function createIframe() {
+    let iframe = document.createElement('iframe');
+    iframe.style.width = "100%";
+    iframe.style.height = "600px"; // Ajuster selon les besoins
+    return iframe;
+}
+
+// Étape 3 : Configurer l'URL de la nouvelle iframe
+function setIframeSrc(iframe, baseUrl, queryParams) {
+    iframe.src = `${baseUrl}?${queryParams}`;
+}
+
 // Faire un loop sur le tableau
 pagesToLeftPannel_.forEach(page => {
     addTweak(page.url, page.option, function() {

--- a/aati.js
+++ b/aati.js
@@ -117,7 +117,7 @@ addTweak(urlAATI, 'autoAATI', function () {
 
 
     // Envoi du document à l'assistant
-    addTweak('https://secure.weda.fr/BinaryData.aspx', "*", function () {
+    addTweak('https://secure.weda.fr/BinaryData.aspx', "*sendDocToCompanion", function () {
         chrome.storage.local.get(['autoAATIexit'], function (result) {
             getOption('RemoveLocalCompanionPrint', function (RemoveLocalCompanionPrint) {
                 if (Date.now() - result.autoAATIexit < 10000 && RemoveLocalCompanionPrint === false) {

--- a/background.js
+++ b/background.js
@@ -48,6 +48,7 @@ var defaultSettings = {
   'MoveHistoriqueToLeft_Certificat': true,
   'MoveHistoriqueToLeft_Demande': true,
   'MoveHistoriqueToLeft_Courrier': false,
+  'MoveHistoriqueToLeft_Formulaire': false,
   'ShowExplanatoryText': true,
   'autoOpenOrdoType': false,
   'defautDataType': 'TAILLE:cm,Taille:cm,POIDS:kg,Poids:kg,Pc:cm,IMC:p/t²,PAd:mmHg,PAs:mmhg,TAS:mmHg,TAD:mmHg,FC:bpm,Sat:%',

--- a/content.js
+++ b/content.js
@@ -136,7 +136,6 @@ function addTweak(url, option, callback) {
     }
 
     if (urlMatches) {
-        console.log(`[addTweak] ${option} activé`);
         // permet de gérer les options en négatif
         let invert = false;
         if (typeof option === 'string' && option.startsWith('!')) {
@@ -146,11 +145,13 @@ function addTweak(url, option, callback) {
         if (typeof option === 'string' && typeof callback === 'function') {
             // Si une seule option et un seul callback sont passés, on les utilise directement
             // ça fait un appel à la fonction plus court
+            console.log(`[addTweak] ${option} activé`);
             executeOption(option, callback, invert);
         } else if (Array.isArray(option) && option.length > 0) {
             // Si un tableau d'options et de callbacks est passé, on les utilise tous
             // permet de ne pas avoir à écrire plusieurs fois la même condition
             option.forEach(({ option, callback }) => {
+                console.log(`[addTweaks] ${option} activé`);
                 executeOption(option, callback, invert);
             });
         }
@@ -523,7 +524,7 @@ let homePageFunctions = [
     },
 ];
 
-addTweak(homePageUrls, homePageFunctions);
+addTweak(homePageUrls, homePageFunctions); //TODO à vérifier : semble engendrer un message abscond dans la console
 
 
 
@@ -629,7 +630,7 @@ addTweak('*', 'WarpButtons', function () {
 });
 
 // Page HRPIM
-addTweak('https://secure.weda.fr/FolderMedical/HprimForm.aspx', '*', function () {
+addTweak('https://secure.weda.fr/FolderMedical/HprimForm.aspx', '*HPRIMtweak', function () {
     function makeHPRIMListSticky() {
         let element = document.querySelector("#ContentPlaceHolder1_UpdatePanelHprimsGrid");
         element.style.position = "sticky";
@@ -685,7 +686,7 @@ addTweak('https://secure.weda.fr/FolderMedical/WedaEchanges/', 'secureExchangeUn
 
 
 // Sélection automatique du type de document pour les courriers envoyés au DMP
-addTweak('https://secure.weda.fr/FolderMedical/CourrierForm.aspx', '*', function () {
+addTweak('https://secure.weda.fr/FolderMedical/CourrierForm.aspx', '*autoDocTypeSelection', function () {
     let dropDownMenu = document.querySelector('#ContentPlaceHolder1_DropDownListDocumentTypes');
     function watchDocumentTypeCourrierDMP() {
         dropDownMenu.addEventListener('change', function () {
@@ -708,7 +709,7 @@ addTweak('https://secure.weda.fr/FolderMedical/CourrierForm.aspx', '*', function
 
 
 // Sélection automatique du champ "titre" lors de la création d'un antécédent.
-addTweak('https://secure.weda.fr/FolderMedical/AntecedentForm.aspx', '*', function () {
+addTweak('https://secure.weda.fr/FolderMedical/AntecedentForm.aspx', '*autoSelectTitleField', function () {
     lightObserver('#ContentPlaceHolder1_TextBoxAntecedentNom', function (elements) {
         elements[0].focus();
     });

--- a/keyCommands.js
+++ b/keyCommands.js
@@ -120,16 +120,21 @@ function addShortcuts(keyCommands, scope, scopeName) {
 function addShortcutsToIframe() {
     var iframes = document.querySelectorAll('iframe');
     if (iframes.length !== 0) {
-        hotkeys.setScope('iframe1');
+        hotkeys.unbind();
         iframes.forEach(function(iframe, index) {
+            let scopeName = 'iframe' + (index + 1);
+            hotkeys.setScope(scopeName);    
             console.log('iframe' + (index + 1), iframe);
-            addShortcuts(keyCommands, iframe.contentDocument, 'iframe' + (index + 1));
+            addShortcuts(keyCommands, iframe.contentDocument, scopeName);
         });
+        addShortcuts(keyCommands, document, 'all');
     }
 }
 
 // Ajout des raccourcis claviers sur le document racine
-addShortcuts(keyCommands, document, 'all');
+setTimeout(function() {
+    addShortcutsToIframe(); // ajoute les raccourcis à toutes les iframes dès le chargement de la page
+}, 20);
 afterMutations(300, addShortcutsToIframe, "ajout raccourcis aux iframes"); // ajoute les raccourcis à toutes les iframes après chaque mutation du document
 
 

--- a/keyCommands.js
+++ b/keyCommands.js
@@ -11,7 +11,6 @@
 const keyCommands = {
     'push_valider':  push_valider,
     'push_annuler': push_annuler,
-    // 'download_document': startDownload, => en attente de https://github.com/Refhi/Weda-Helper/pull/106
     'print_meds': function () {
             printIfOption(0);
         },    

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Weda Helper",
-  "version": "2.3.9.1",
+  "version": "2.3.9.2",
   "options_page": "options.html",
   "permissions": ["storage"],
   "host_permissions": ["http://localhost/"],

--- a/manifest.json
+++ b/manifest.json
@@ -16,6 +16,7 @@
     {
       "matches": ["*://secure.weda.fr/*"],
       "js": [
+          "hotkeys.js",
           "content.js",
           "Consultation.js",
           "fse.js",
@@ -26,7 +27,6 @@
           "update.js",
           "aati.js",
           "metrics.js",
-          "hotkeys.js",
           "upload.js"]
     }
   ]

--- a/upload.js
+++ b/upload.js
@@ -1,5 +1,5 @@
 // Fonctions permettant l'upload automatique d'un fichier transmis par le Companion
-addTweak('https://secure.weda.fr/FolderMedical/PopUpUploader.aspx', '*', function() {
+addTweak('https://secure.weda.fr/FolderMedical/PopUpUploader.aspx', '*hotkeyUpload', function() {
 
     chrome.storage.local.get('automaticUpload', function(result) { //On vérifie que le flag automaticUpload est bien présent
         if (result.automaticUpload == true) {


### PR DESCRIPTION
Résous deux problèmes :
- l'affichage de l'historique à gauche était lourd, et nécessitait le rafraîchissement complet de la page => c'est maintenant une iframe crée pour l'occasion qui prend le relais, et on ne touche plus au bouton 'historique'
- les raccourcis claviers étaient parfois injectés plusieurs fois sur le même élément,  ce qui faisait planter => ils sont désormais nettoyés avant toute nouvelle injection. Un peu plus lourd, mais s'active lorsque la page a fini le chargement, donc transparent pour l'utilisateur.