### PR TITLE
v2.4.1 - hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,13 @@
 Toutes les modifications notables de ce projet seront documentées dans ce fichier.
 
 # [2.4.1] - ... - bugfix
-## fix :
-- les courbes pédiatriques s'affichent désormais devant l'historique de gauche
-- les documents joint à une consultation/Demande/etc. s'affichent désormais devant les autres éléments
+## fix de bugs :
+- #152 - L'option "Ouvre automatiquement la fenêtre des ordonnances-types lors des prescriptions médicamenteuses" empêchait la rédaction d'un conseil médicamenteux
+- #153 - De nouveau superpositions quand ouverture d'un document joint lors d'une consultation
+- #154 - La recherche de médicament s'efface lors d'un premier lancement de Weda dans certaines conditions
+- #155 - Courbes pédiatriques vont derrière l'iframe de l'history2Left
+- #149 - Courbes pédiatriques HS si "Activer la navigation entre les valeurs de suivi avec la touche Tab dans les consultations." est décochée
+- #161 - bug bouton impression manquant dans certificat si affichage historique activé
 
 # [2.4] - 28/06/2024
 ## ajout :

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Toutes les modifications notables de ce projet seront documentées dans ce fichi
 # [2.4.1] - ... - bugfix
 ## fix :
 - les courbes pédiatriques s'affichent désormais devant l'historique de gauche
+- les documents joint à une consultation/Demande/etc. s'affichent désormais devant les autres éléments
 
 # [2.4] - 28/06/2024
 ## ajout :

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Toutes les modifications notables de ce projet seront documentées dans ce fichier.
 
+# [2.4.1] - ... - bugfix
+## fix :
+- les courbes pédiatriques s'affichent désormais devant l'historique de gauche
+
 # [2.4] - 28/06/2024
 ## ajout :
 - Décocher automatiquement le message et le fichier IHE_XDM.zip lors de l'importation d'un message depuis la messagerie sécurisée

--- a/Consultation.js
+++ b/Consultation.js
@@ -8,11 +8,31 @@ addTweak('https://secure.weda.fr/FolderMedical/ConsultationForm.aspx', 'TweakTab
         }
     }
 
-    lightObserver('[id^="ContentPlaceHolder1_SuivisGrid_EditBoxGridSuiviReponse_"]', changeTabOrder)
-    console.log('ConsultationFormTabOrderer started');
-    // ici aussi les métriques sont difficiles à évaluer. Si on considère environs
-    // 2 éléments par consultation, on peut estimer en gros à 1 clic + 1 drag par consultation
-    recordMetrics({ clicks: 1, drags: 1 });
+    lightObserver('[id^="ContentPlaceHolder1_SuivisGrid_EditBoxGridSuiviReponse_"]', function(elements) {
+        changeTabOrder(elements)
+        console.log('ConsultationFormTabOrderer started');
+        // ici aussi les métriques sont difficiles à évaluer. Si on considère environs
+        // 2 éléments par consultation, on peut estimer en gros à 1 clic + 1 drag par consultation
+        recordMetrics({ clicks: 1, drags: 1 });
+    });
+});
+
+addTweak('https://secure.weda.fr/FolderMedical/ConsultationForm.aspx', '*CourbesPediatriques', function () {
+    // Modifier l'ordre de tabulation des valeurs de suivi    
+    function changeTabOrder(elements) {
+        console.log('changeTabOrder started');
+        for (var i = 0; i < elements.length; i++) {
+            elements[i].tabIndex = i + 1;
+        }
+    }
+
+    lightObserver('[id^="ContentPlaceHolder1_SuivisGrid_EditBoxGridSuiviReponse_"]', function(elements) {
+        changeTabOrder(elements)
+        console.log('ConsultationFormTabOrderer started');
+        // ici aussi les métriques sont difficiles à évaluer. Si on considère environs
+        // 2 éléments par consultation, on peut estimer en gros à 1 clic + 1 drag par consultation
+        recordMetrics({ clicks: 1, drags: 1 });
+    });
 
 
     // Afficher en overlay une image issue d'une URL en cas de survol de certains éléments
@@ -26,8 +46,8 @@ addTweak('https://secure.weda.fr/FolderMedical/ConsultationForm.aspx', 'TweakTab
         "Taille-Poids : 18 ans (M)": { "TC": "15", "Question": "Taille", "Genre": "M", "AgeMin": 3, "AgeMax": 18 },
         "IMC : 18 ans": { "TC": "16", "Question": "IMC", "Genre": "F", "AgeMin": 0, "AgeMax": 18 },
         "IMC : 18 ans (M)": { "TC": "17", "Question": "IMC", "Genre": "M", "AgeMin": 0, "AgeMax": 18 },
-        "Garçon 0 mois à 6 mois (OMS)": { "TC": "18", "Question": "Poids", "Genre": "M", "AgeMin": 0, "AgeMax": 1 },
-        "Fille 0 mois à 6 mois (OMS)": { "TC": "19", "Question": "Poids", "Genre": "F", "AgeMin": 0, "AgeMax": 1 }
+        "Garçon 0 mois à 6 mois (OMS)": { "TC": "18", "Question": "Poids", "Genre": "M", "AgeMin": 0, "AgeMax": 0 },
+        "Fille 0 mois à 6 mois (OMS)": { "TC": "19", "Question": "Poids", "Genre": "F", "AgeMin": 0, "AgeMax": 0 }
     };
 
     // // Récupère les valeurs de genre et d'âge dans la page.
@@ -81,6 +101,7 @@ addTweak('https://secure.weda.fr/FolderMedical/ConsultationForm.aspx', 'TweakTab
             tooltip.style.top = '50%';
             tooltip.style.left = '50%';
             tooltip.style.transform = 'translate(-50%, -50%)';
+            tooltip.style.zIndex = '1000';
             return tooltip;
         }
 

--- a/Consultation.js
+++ b/Consultation.js
@@ -249,7 +249,7 @@ let pagesToLeftPannel_ = [
     },
     {
         url: 'https://secure.weda.fr/FolderMedical/CertificatForm.aspx',
-        targetElementSelector: '#CE_ContentPlaceHolder1_EditorCertificat_ID',
+        targetElementSelector: '#form1 > div:nth-child(15) > table > tbody > tr > td:nth-child(1) > table > tbody > tr',
         option: 'MoveHistoriqueToLeft_Certificat',
         pageType: 'Certificat'
     },
@@ -383,7 +383,7 @@ function historyToLeft() {
     pagesToLeftPannel_.forEach(page => {
         addTweak(page.url, page.option, () => {
             const targetElement = document.querySelector(page.targetElementSelector);
-            const iframe = createIframe(targetElement);
+            const iframe = createIframe(targetElement); // ici targetElement est nécessaire comme référence pour l'insertion de l'iframe
             iframe.addEventListener('load', () => {
                 removeElements(iframe.contentDocument);
             });

--- a/Consultation.js
+++ b/Consultation.js
@@ -136,7 +136,7 @@ addTweak('https://secure.weda.fr/FolderMedical/ConsultationForm.aspx', '*Courbes
             let explanationText = createExplanatoryText();
             tooltip.appendChild(loadingText);
             tooltip.appendChild(img);
-            element.appendChild(tooltip);
+            document.body.appendChild(tooltip);
 
             element.addEventListener('mouseover', function () {
                 let imageUrl = urlImage(key);
@@ -299,6 +299,7 @@ function createIframe(targetElement) {
     iframe.style.position = 'absolute'; // ou 'fixed' si vous voulez qu'elle reste en place lors du défilement
     iframe.style.left = '0px'; // Aligné avec le bord gauche
     iframe.style.border = "none";
+    iframe.style.zIndex = '-1';
     // Injecter l'iframe dans le DOM proche de targetElement pour que ça soit au même niveau (sur l'axe vertical)
     const parent = targetElement.parentNode;
     if (parent) {
@@ -345,6 +346,7 @@ function adjustLayout(pageType, iframe, targetElement) {
     targetElement.style.left = `${iframe.getBoundingClientRect().right}px`;
     targetElement.style.marginTop = '0px';
     targetElement.style.width = `${targetElementWidth}px`;
+    targetElement.style.zIndex = '-1';
 
     if (["Certificat", "Demande", "Courrier"].includes(pageType)) {
         moveAndResizeDocTypes(availableWidth);

--- a/keyCommands.js
+++ b/keyCommands.js
@@ -108,7 +108,7 @@ function addShortcuts(keyCommands, scope, scopeName) {
         hotkeys.filter = function(event){
             return true; // Permet d'utiliser les raccourcis depuis un input ou un textarea
         }
-        console.log('[addShortcuts] ajout des raccourcis sur element', scope, 'avec scopeName', scopeName, 'et result', result);
+        // console.log('[addShortcuts] ajout des raccourcis sur element', scope, 'avec scopeName', scopeName, 'et result', result);
         for (let key in keyCommands) {
             action = keyCommands[key];
             shortcut = shortcutDefaut(result.shortcuts, result.defaultShortcuts, key);
@@ -123,13 +123,14 @@ function addShortcutsToIframe() {
         iframes.forEach(function(iframe, index) {
             let scopeName = 'iframe' + (index + 1);
             hotkeys.setScope(scopeName);    
-            console.log('iframe' + (index + 1), iframe);
+            // console.log('iframe' + (index + 1), iframe);
             addShortcuts(keyCommands, iframe.contentDocument, scopeName);
         });
     }
 }
 
 function addAllShortcuts() {
+    console.log('[addAllShortcuts] activé');
     hotkeys.unbind(); // nécessaire pour éviter les doublons de raccourcis clavier entrainant des doublons de documents...
     addShortcuts(keyCommands, document, 'all');
     addShortcutsToIframe();

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Weda Helper",
-  "version": "2.4",
+  "version": "2.4.1",
   "options_page": "options.html",
   "permissions": ["storage"],
   "host_permissions": ["http://localhost/"],

--- a/prescription.js
+++ b/prescription.js
@@ -173,15 +173,13 @@ if (PrescriptionForm) {
 }
 
 addTweak(prescriptionUrl, 'autoOpenOrdoType', function() {
-    // window.onload = function() { // paradoxalement plus fiable sans !
-        document.getElementById('ContentPlaceHolder1_ButtonPrescritionType').click();
-        afterMutations(100, function() { //On remet le focus sur la barre de recherche, nécessite un petit délai
-            var inputField = document.getElementById('ContentPlaceHolder1_BaseVidalUcForm1_TextBoxFindPack');
-            if (inputField) {
-                inputField.focus();
-            }
-        });
-    // };
+    document.getElementById('ContentPlaceHolder1_ButtonPrescritionType').click();
+    lightObserver("#ContentPlaceHolder1_BaseGlossaireUCForm2_UpdatePanelDocument", function() {
+        var inputField = document.getElementById('ContentPlaceHolder1_BaseVidalUcForm1_TextBoxFindPack');
+        if (inputField) {
+            inputField.focus();
+        }
+    });
 });
 
 

--- a/prescription.js
+++ b/prescription.js
@@ -166,8 +166,8 @@ if (PrescriptionForm) {
                 }
             }
         }
-
         lightObserver('#ContentPlaceHolder1_BaseVidalUcForm1_DropDownListRecherche', onDOMChange);
+        onDOMChange() // a priori nécessaire sur certains setups en plus du lightObserver
     });
 
 }

--- a/update.js
+++ b/update.js
@@ -6,19 +6,14 @@ function htmlMaker(text) {
 }
 
 var nouveautes = `
-# [2.4] - 28/06/2024
-## ajout :
-- Décocher automatiquement le message et le fichier IHE_XDM.zip lors de l'importation d'un message depuis la messagerie sécurisée
-- Sélection automatique du type d'ordonnance numérique quand il s'agit d'une Demande, et qu'un mot-clé est détecté : (infirmierRegex = /IDE|infirmier|pansement|injection/i; kineRegex = /kiné|kine|kinésithérapie|kinesitherapie|MKDE|kinesitherapeute|kinesithérapeute/i; pedicureRegex = /pédicure|pedicure|podologie|podologique|podologue/i; orthophonieRegex = /orthophonie|orthophonique|orthophoniste/i; let orthoptieRegex = /orthoptie|orthoptique|orthoptiste/i;) => n'hésitez pas à nous demander d'ajouter d'autres mot-clés pertinents.
-- 2 raccourcis désormais possibles selon le modèle d'impression preféré, idem pour les téléchargements : Ctrl+P pour l'impression et Ctrl+D pour le téléchargement pour le premier modèle, et Ctrl+Shift+P et Ctrl+Shift+D pour le second modèle.
-- détection automatique du Companion s'il est en route, mais n'est pas activé dans les options de Weda-Helper
-
-## fix :
-- le focus reste dans le champ de recherche après l'ouverture automatique des prescriptions-types
-- blocage du historyToLeft si une fenêtre de prévisualisation est ouverte pour éviter des superpositions
-- alt+V fonctionne désormais aussi pour valider l'import de documents
-- message [addTweak] plus explicite dans la console
-- amélioration du Readme, notamment la partie sur le Companion et les raccourcis claviers
+v2.4.1 - hotfix
+## (les numéros correspondent aux "issues" sur github)
+- #152 - L'option "Ouvre automatiquement la fenêtre des ordonnances-types lors des prescriptions médicamenteuses" empêchait la rédaction d'un conseil médicamenteux
+- #153 - De nouveau superpositions quand ouverture d'un document joint lors d'une consultation
+- #154 - La recherche de médicament s'efface lors d'un premier lancement de Weda dans certaines conditions
+- #155 - Courbes pédiatriques vont derrière l'iframe de l'history2Left
+- #149 - Courbes pédiatriques HS si "Activer la navigation entre les valeurs de suivi avec la touche Tab dans les consultations." est décochée
+- #161 - bug bouton impression manquant dans certificat si affichage historique activé
 `
 
 nouveautes = htmlMaker(nouveautes)


### PR DESCRIPTION
- #152 - L'option "Ouvre automatiquement la fenêtre des ordonnances-types lors des prescriptions médicamenteuses" empêchait la rédaction d'un conseil médicamenteux
- #153 - De nouveau superpositions quand ouverture d'un document joint lors d'une consultation
- #154 - La recherche de médicament s'efface lors d'un premier lancement de Weda dans certaines conditions
- #155 - Courbes pédiatriques vont derrière l'iframe de l'history2Left
- #149 - Courbes pédiatriques HS si "Activer la navigation entre les valeurs de suivi avec la touche Tab dans les consultations." est décochée
- #161 - bug bouton impression manquant dans certificat si affichage historique activé