### PR TITLE
fix #102 et #101

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 Toutes les modifications notables de ce projet seront documentées dans ce fichier.
+# [2.5.0] - 
+## ajout :
+- [#101](https://github.com/Refhi/Weda-Helper/issues/101) - Ajout d'une cotation par défaut selon le mode de la FSE
+=> vous pouvez désormais créer une cotation "DéfautALD" dans vos favoris et elle sera automatiquement sélectionnée lors de la création d'une FSE en mode ALD
+=> idem pour "DéfautPédia" qui sera automatiquement sélectionnée pour les enfants 0-6 ans
+
 
 # [2.4.2] - 01/07/2024
 ## fix 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,10 @@ Lors de l'usage de la calculette il devient possible d'utiliser les chiffres du 
 *Toute la FSE : [alt+6], [n], [n], [alt+v]*
 - les touches "n" et "o" permettent de sélectionner "non"/"oui" pour accidents de droit commun, puis ALD
 - les touches "t" et "c" permettent de sélectionner les tiers payants correspondants (AMO et AMC)
-- Si elles sont utilisées, entre automatiquement la cotation par défaut (Une de vos cotations favorites doit être nommée 'Défaut')
+- Si elles sont utilisées, utilise une cotation dans vos favoris :
+  - la cotation "DéfautPédia" pour les 0-6 ans
+  - la cotation "DéfautALD" pour les ALD
+  - la cotation "Défaut" pour les autres 
 - Lecture automatique de la carte vitale si elle est non lue
 - Affichage de boutons directs pour la réalisation de FDS dégradées et téléconsultation
 - Option pour cocher automatiquement "accident causé par un tier" ou "gestion unique"

--- a/fse.js
+++ b/fse.js
@@ -4,7 +4,7 @@
 // (tableau et bouche après)
 function tweakFSECreation() {
     // Make a dictionnary with keystrokes and their corresponding actions
-    var index = { // TODO à passer dans hotkey.js
+    var index = {
         'n': ['mat-radio-9-input', 'mat-radio-3-input'],
         'o': ['mat-radio-8-input', 'mat-radio-2-input'],
         't': ['mat-checkbox-1-input'],
@@ -211,18 +211,53 @@ function tweakFSECreation() {
 
 
     function setDefaultValue() {
-        // set defaut value
+        // Si on envisage d'ajouter des cotations automatisées plus complexes, on pourra simplement se greffer sur cette fonction
+        // par exemple en mettant dans une des conditions la récupération d'une valeur mémoire spécifique
+        let conditionalCotations = [
+            {
+                condition: function() {
+                    let isALD = document.querySelector('#mat-radio-2-input').checked;
+                    return isALD;
+                },
+                action: 'DéfautALD'
+            },
+            {
+                condition: function() {
+                    let ageString = document.querySelector('#LabelInfoPatientNom > span > span:nth-child(4)').textContent;
+                    let age = parseInt(ageString.match(/\d+/)[0]);
+                    console.log('Age du patient :', age);
+                    return age < 7;
+                },
+                action: 'DéfautPédia'
+            },
+            {
+                condition: function() {
+                    return true; // Cette condition sera toujours vraie pour la cotation "Défaut"
+                },
+                action: 'Défaut'
+            },            
+        ];
+
+        // Définit la cotation par défaut
         addTweak('*', 'defaultCotation', function() {
             var elements = document.querySelectorAll('.flexRow.favoris.ng-star-inserted');
             console.log('elements', elements);
-            var defautElement = Array.from(elements).find(el => el.textContent.trim().includes('Défaut'));
-            if (defautElement) {
-                defautElement.click();
-                recordMetrics({clicks: 1, drags: 1});
-            } else {
-                console.log('Aucun élément contenant "Défaut" n\'a été trouvé.');
-                alert('Weda-Helper : "cotation par défaut" n\'est pas désactivé dans les options, mais aucune cotation favorite nommée "Défaut" n\'a été trouvé. Vous devez soit ajouter un favori nommé exactement "Défaut", soit désactiver l\'option "cotation par défaut" dans les options de Weda-Helper. Ce changement est rendu nécessaire par la dernière mise à jour.');
+
+            for (let i = 0; i < conditionalCotations.length; i++) {
+                if (conditionalCotations[i].condition()) {
+                    let action = conditionalCotations[i].action;
+                    let targetElement = Array.from(elements).find(el => el.textContent.trim().includes(action));
+                    if (targetElement) {
+                        targetElement.click();
+                        recordMetrics({clicks: 1, drags: 1});
+                        console.log('Cotation appliquée:', action);
+                        return; // Arrête la fonction après avoir appliqué une cotation
+                    }
+                }
             }
+
+            // Si aucune condition n'est remplie, afficher un message d'erreur
+            console.log('Aucune condition remplie pour appliquer une cotation spécifique.');
         });
     }
 

--- a/fse.js
+++ b/fse.js
@@ -223,7 +223,7 @@ function tweakFSECreation() {
             },
             {
                 condition: function() {
-                    let ageString = document.querySelector('#LabelInfoPatientNom > span > span:nth-child(4)').textContent;
+                    let ageString = document.querySelector('#LabelInfoPatientNom > span > span:last-child').textContent;
                     let age = parseInt(ageString.match(/\d+/)[0]);
                     console.log('Age du patient :', age);
                     return age < 7;
@@ -243,10 +243,11 @@ function tweakFSECreation() {
             var elements = document.querySelectorAll('.flexRow.favoris.ng-star-inserted');
             console.log('elements', elements);
 
-            for (let i = 0; i < conditionalCotations.length; i++) {
-                if (conditionalCotations[i].condition()) {
-                    let action = conditionalCotations[i].action;
-                    let targetElement = Array.from(elements).find(el => el.textContent.trim().includes(action));
+            for (let i = 0; i < conditionalCotations.length; i++) { // Loop dans le dico des cotations conditionnelles
+                if (conditionalCotations[i].condition()) {// Si la condition est remplie
+                    let action = conditionalCotations[i].action; // L'action c'est le nom du favori à appliquer
+                    let targetElement = Array.from(elements).find(el => el.textContent.trim() === 'keyboard_arrow_right'+action);
+                    // keyboard_arrow_right est nécessaire pour matcher le texte complet du favori qui contient ">" devant le nom
                     if (targetElement) {
                         targetElement.click();
                         recordMetrics({clicks: 1, drags: 1});

--- a/fse.js
+++ b/fse.js
@@ -252,6 +252,10 @@ function tweakFSECreation() {
                         recordMetrics({clicks: 1, drags: 1});
                         console.log('Cotation appliquée:', action);
                         return; // Arrête la fonction après avoir appliqué une cotation
+                    } else if (action === 'Défaut') {
+                        console.log('Action "Défaut" spécifiée mais non trouvée parmi les éléments.');
+                        alert('Weda-Helper : "cotation par défaut" n\'est pas désactivé dans les options, mais aucune cotation favorite nommée "Défaut" n\'a été trouvé. Vous devez soit ajouter un favori nommé exactement "Défaut", soit désactiver l\'option "cotation par défaut" dans les options de Weda-Helper. Vous pouvez également définir DéfautPédia et DéfautALD.');
+                        return; // Arrête la fonction si "Défaut" est spécifié mais non trouvé
                     }
                 }
             }


### PR DESCRIPTION
- [#101](https://github.com/Refhi/Weda-Helper/issues/101) - Ajout d'une cotation par défaut selon le mode de la FSE
=> vous pouvez désormais créer une cotation "DéfautALD" dans vos favoris et elle sera automatiquement sélectionnée lors de la création d'une FSE en mode ALD
=> idem pour "DéfautPédia" qui sera automatiquement sélectionnée pour les enfants 0-6 ans