### PR TITLE
fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,16 @@ Toutes les modifications notables de ce projet sont documentées dans ce fichier
 
 Si vous souhaitez voir le détail, cliquez sur les numéros qui vous renverrons vers les tickets correspondants.
 
-# [2.11.1] - fix
+# [2.11.2] - fix
 ## Fix :
-- [#377](https://github.com/Refhi/Weda-Helper/issues/377) - Les onglets se ferment de façon fiable même en l'absence du DMP (ce fix est à tester, merci de me faire part de vos retours si vous constatez encore des onglets ne se fermant pas)
 - [#385](https://github.com/Refhi/Weda-Helper/issues/385) - La touche Alt ne met plus le focus sur le menu du navigateur (désactivable dans les options). Cela règle deux problèmes : le focus était perdu lors de l'usage de Alt pour afficher l'aide, et lorsque le Companion tente de rendre le focus au navigateur (via un appuis simulé sur la touche Alt) cela entrainait parfois un focus sur le menu du navigateur.
 - [#377](https://github.com/Refhi/Weda-Helper/issues/377) - Ajout d'un message d'erreur plus explicite si le retour du Companion n'est pas détecté en suggerant de vérifier le firewall.
 - [#386](https://github.com/Refhi/Weda-Helper/issues/386) - Ajout de logs pour déboguer un problème présent avec le mot-clé "psychologue" qui n'annule pas correctement l'ordonnance numérique.
+
+
+# [2.11.1] - fix
+## Fix :
+- [#377](https://github.com/Refhi/Weda-Helper/issues/377) - Les onglets se ferment de façon fiable même en l'absence du DMP (ce fix est à tester, merci de me faire part de vos retours si vous constatez encore des onglets ne se fermant pas)
 
 # [2.11] - À retrouver facilement dans le menu de l'extension si vous n'avez pas le temps de lire maintenant !
 ## Améliorations :

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Si vous souhaitez voir le détail, cliquez sur les numéros qui vous renverrons 
 - [#377](https://github.com/Refhi/Weda-Helper/issues/377) - Les onglets se ferment de façon fiable même en l'absence du DMP (ce fix est à tester, merci de me faire part de vos retours si vous constatez encore des onglets ne se fermant pas)
 - [#385](https://github.com/Refhi/Weda-Helper/issues/385) - La touche Alt ne met plus le focus sur le menu du navigateur (désactivable dans les options). Cela règle deux problèmes : le focus était perdu lors de l'usage de Alt pour afficher l'aide, et lorsque le Companion tente de rendre le focus au navigateur (via un appuis simulé sur la touche Alt) cela entrainait parfois un focus sur le menu du navigateur.
 - [#377](https://github.com/Refhi/Weda-Helper/issues/377) - Ajout d'un message d'erreur plus explicite si le retour du Companion n'est pas détecté en suggerant de vérifier le firewall.
+- [#386](https://github.com/Refhi/Weda-Helper/issues/386) - Ajout de logs pour déboguer un problème présent avec le mot-clé "psychologue" qui n'annule pas correctement l'ordonnance numérique.
 
 # [2.11] - À retrouver facilement dans le menu de l'extension si vous n'avez pas le temps de lire maintenant !
 ## Améliorations :

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Si vous souhaitez voir le détail, cliquez sur les numéros qui vous renverrons 
 # [2.11.1] - fix
 ## Fix :
 - [#377](https://github.com/Refhi/Weda-Helper/issues/377) - Les onglets se ferment de façon fiable même en l'absence du DMP (ce fix est à tester, merci de me faire part de vos retours si vous constatez encore des onglets ne se fermant pas)
+- [#385](https://github.com/Refhi/Weda-Helper/issues/385) - La touche Alt ne met plus le focus sur le menu du navigateur (désactivable dans les options). Cela règle deux problèmes : le focus était perdu lors de l'usage de Alt pour afficher l'aide, et lorsque le Companion tente de rendre le focus au navigateur (via un appuis simulé sur la touche Alt) cela entrainait parfois un focus sur le menu du navigateur.
 
 # [2.11] - À retrouver facilement dans le menu de l'extension si vous n'avez pas le temps de lire maintenant !
 ## Améliorations :

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Si vous souhaitez voir le détail, cliquez sur les numéros qui vous renverrons 
 ## Fix :
 - [#377](https://github.com/Refhi/Weda-Helper/issues/377) - Les onglets se ferment de façon fiable même en l'absence du DMP (ce fix est à tester, merci de me faire part de vos retours si vous constatez encore des onglets ne se fermant pas)
 - [#385](https://github.com/Refhi/Weda-Helper/issues/385) - La touche Alt ne met plus le focus sur le menu du navigateur (désactivable dans les options). Cela règle deux problèmes : le focus était perdu lors de l'usage de Alt pour afficher l'aide, et lorsque le Companion tente de rendre le focus au navigateur (via un appuis simulé sur la touche Alt) cela entrainait parfois un focus sur le menu du navigateur.
+- [#377](https://github.com/Refhi/Weda-Helper/issues/377) - Ajout d'un message d'erreur plus explicite si le retour du Companion n'est pas détecté en suggerant de vérifier le firewall.
 
 # [2.11] - À retrouver facilement dans le menu de l'extension si vous n'avez pas le temps de lire maintenant !
 ## Améliorations :

--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ Installez et laisser tourner ce logiciel sur votre ordinateur pour avoir des fon
 - Envoie le montant à régler à votre TPE (quand on valide une FSE - via alt+v - ou un règlement manuel)
 - un lien vers le journal d'activité du Companion est présent dans la page des options de Weda-Helper
 => Procédures d'installation et de paramétrage sur [le readme du Companion](https://github.com/Refhi/Weda-Helper-Companion)
+- pensez à vérifier votre firewall s'il ne fonctionne pas ou si des messages type "Impossible de joindre Weda-Helper-Companion : est-il bien paramétré et démarré ?" apparaissent.
 
 
 ## Problèmes et limitations connues (qui seront peut-être résolues dans de futures mises à jour):

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Installez et laisser tourner ce logiciel sur votre ordinateur pour avoir des fon
 - Envoie le montant à régler à votre TPE (quand on valide une FSE - via alt+v - ou un règlement manuel)
 - un lien vers le journal d'activité du Companion est présent dans la page des options de Weda-Helper
 => Procédures d'installation et de paramétrage sur [le readme du Companion](https://github.com/Refhi/Weda-Helper-Companion)
-- pensez à vérifier votre firewall s'il ne fonctionne pas ou si des messages type "Impossible de joindre Weda-Helper-Companion : est-il bien paramétré et démarré ?" apparaissent.
+- pensez à vérifier votre firewall s'il ne fonctionne pas ou si des messages type "Impossible de joindre Weda-Helper-Companion : est-il bien paramétré et démarré ?" apparaissent. Cf. [Guide de dépannage sur le firewall windows](https://github.com/Refhi/Weda-Helper/issues/377#issuecomment-2716796999)
 
 
 ## Problèmes et limitations connues (qui seront peut-être résolues dans de futures mises à jour):

--- a/aati.js
+++ b/aati.js
@@ -201,10 +201,10 @@ addTweak(urlAATI, 'autoAATI', function () {
                             });
                         })
                         .catch(error => {
-                            console.warn(errortype + ' Impossible de joindre Weda-Helper-Companion : est-il bien paramétré et démarré ? Erreur:', error);
+                            console.warn(errortype + ' Impossible de joindre Weda-Helper-Companion : est-il bien paramétré et démarré ? Erreur:', error, 'Problème de Firewall ?');
                             if (!errortype.includes('[focus]')) {
                                 sendWedaNotifAllTabs({
-                                    message: 'Impossible de joindre Weda-Helper-Companion : est-il bien paramétré et démarré ? Erreur: ' + error,
+                                    message: 'Impossible de joindre Weda-Helper-Companion : est-il bien paramétré et démarré ? Erreur: ' + error + 'Problème de Firewall ?',
                                     type: 'fail',
                                     icon: 'print'
                                 })

--- a/background.js
+++ b/background.js
@@ -633,6 +633,12 @@ var advancedDefaultSettings = [{
         "type": TYPE_BOOL,
         "description": "Affiche l'interface de test des permissions des onglets.",
         "default": false
+    },{
+        "name": "inhitAltKey",
+        "type": TYPE_BOOL,
+        "description": "La touche Alt ne met plus le focus sur le menu du navigateur",
+        "default": true,
+        "longDescription": "Cela règle deux problèmes : le focus était perdu lors de l'usage de Alt pour afficher l'aide, et lorsque le Companion tente de rendre le focus au navigateur (via un appuis simulé sur la touche Alt) cela entrainait parfois un focus sur le menu du navigateur."
     }],
 }];
 

--- a/companionLink.js
+++ b/companionLink.js
@@ -56,11 +56,11 @@ function sendToCompanion(urlCommand, blob = null, callback = null, callbackWithD
                         return;
                     }
                 }
-                console.warn(errortype + ' Impossible de joindre Weda-Helper-Companion : est-il bien paramétré et démarré ? Erreur:', error);
+                console.warn(errortype + ' Impossible de joindre Weda-Helper-Companion : est-il bien paramétré et démarré ? Erreur:', error, 'Problème de Firewall ?');
                 if (!errortype.includes('[focus]') && !errortype.includes('tpe')) {
                     // alert(errortype + ' Impossible de joindre Weda-Helper-Companion : est-il bien paramétré et démarré ? Erreur: ' + error);
                     sendWedaNotifAllTabs({
-                        message: 'Impossible de joindre Weda-Helper-Companion : est-il bien paramétré et démarré ? Erreur: ' + error,
+                        message: 'Impossible de joindre Weda-Helper-Companion : est-il bien paramétré et démarré ? Erreur: ' + error + 'Problème de Firewall ?',
                         type: 'fail',
                         icon: 'bug_report'
                     })

--- a/content.js
+++ b/content.js
@@ -246,3 +246,16 @@ addTweak('*', '*middleClickW', function () {
         callback: addMiddleClickEvent
     });
 });
+
+
+// Inhibition du comportement classique de la touche Alt pour ouvrir le menu du navigateur
+// cela facilite l'usage de l'aide (affichée en maintenant Alt appuyé)
+// et de la récupération du focus via le Companion qui simule un Alt
+
+addTweak('*', 'inhitAltKey', function () {
+    window.addEventListener('keydown', function (event) {
+        if (event.key === 'Alt') {
+            event.preventDefault();
+        }
+    });
+});

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
   "name": "Weda Helper",
-  "version": "2.11.1",
-  "version_name": "2.11.1",
+  "version": "2.11.2",
+  "version_name": "2.11.2",
   "options_page": "options.html",
   "permissions": [
     "storage"

--- a/prescription.js
+++ b/prescription.js
@@ -486,9 +486,16 @@ addTweak(demandeUrl, 'autoSelectTypeOrdoNum', function () {
         else {
             console.log('type de soin trouvé', type, 'je clique dessus', choixPossibles[type]);
             if (type === 99) {
-                console.log("Type de soin non éligible à l'ordonnance numérique, je clique sur #targetAnnuler");
+                console.log("[autoSelectTypeOrdoNum] Type de soin non éligible à l'ordonnance numérique, je clique sur 'Continuer sans l'ordonnance numérique'");
                 // Type de soin non éligible à l'ordonnance numérique, je clique sur #targetAnnuler
-                document.querySelector('.targetAnnuler').click();
+                const targetAnnuler = document.querySelectorAll('.mat-button-wrapper');
+                // Rechercher le texte Continuez sans l'ordonnance numérique et cliquer dessus
+                targetAnnuler.forEach(function (element) {
+                    if (element.textContent === "Continuez sans l'ordonnance numérique") {
+                        console.log("[autoSelectTypeOrdoNum] 'Continuez sans l'ordonnance numérique' trouvé, je clique dessus, element", element);
+                        element.click();
+                    }
+                });
             } else {
                 choixPossibles[type].click();
             }


### PR DESCRIPTION
- [#385](https://github.com/Refhi/Weda-Helper/issues/385) - La touche Alt ne met plus le focus sur le menu du navigateur (désactivable dans les options). Cela règle deux problèmes : le focus était perdu lors de l'usage de Alt pour afficher l'aide, et lorsque le Companion tente de rendre le focus au navigateur (via un appuis simulé sur la touche Alt) cela entrainait parfois un focus sur le menu du navigateur.
- [#377](https://github.com/Refhi/Weda-Helper/issues/377) - Ajout d'un message d'erreur plus explicite si le retour du Companion n'est pas détecté en suggerant de vérifier le firewall.
- [#386](https://github.com/Refhi/Weda-Helper/issues/386) - Ajout de logs pour déboguer un problème présent avec le mot-clé "psychologue" qui n'annule pas correctement l'ordonnance numérique.