### PR TITLE
# [2.13.1] - Correctifs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Si vous souhaitez voir le détail, cliquez sur les numéros qui vous renverrons 
 - [#448](https://github.com/Refhi/Weda-Helper/issues/448) - Ignore désormais tout les noms trouvés après le mot-clé "destinataire(s)" dans le dernier tier du document lors de la recherche du médecin addresseur d'un courrier.
 - [#452](https://github.com/Refhi/Weda-Helper/issues/452) - Ignore désormais les lignes contenant plusieurs types d'examens (en général quand le centre d'imagerie annonce ses capacités d'examen).
 - [#464](https://github.com/Refhi/Weda-Helper/issues/464) - Prend en compte le décochage de l'option Titre Automatique (échanges sécurisés).
+- [#464](https://github.com/Refhi/Weda-Helper/issues/464) - Amélioration des messages d'erreurs lors de l'import des échanges sécurisés.
 
 
 # [2.13] - Gel des demandes de fonctionnalités

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Si vous souhaitez voir le détail, cliquez sur les numéros qui vous renverrons 
 ### Imports automatisés :
 - [#448](https://github.com/Refhi/Weda-Helper/issues/448) - Ignore désormais tout les noms trouvés après le mot-clé "destinataire(s)" dans le dernier tier du document lors de la recherche du médecin addresseur d'un courrier.
 - [#452](https://github.com/Refhi/Weda-Helper/issues/452) - Ignore désormais les lignes contenant plusieurs types d'examens (en général quand le centre d'imagerie annonce ses capacités d'examen).
+- [#464](https://github.com/Refhi/Weda-Helper/issues/464) - Prend en compte le décochage de l'option Titre Automatique (échanges sécurisés).
 
 
 # [2.13] - Gel des demandes de fonctionnalités

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ Si vous souhaitez voir le détail, cliquez sur les numéros qui vous renverrons 
 ## Fix :
 - [#465](https://github.com/Refhi/Weda-Helper/issues/465) - L'historique gauche est de nouveau affiché avec 30% de largeur par défaut au lieu des 50% proposé de base par Weda. (actif si l'historique gauche est activé automatiquement dans les consultations)
 - [#459](https://github.com/Refhi/Weda-Helper/issues/459) - Un bouton permet désormais de réinitialiser le classement automatique des documents dans les échanges sécurisés. Cela permet de tester plus facilement différents mots-clés de classification.
-- [#448](https://github.com/Refhi/Weda-Helper/issues/448) - Ignore désormais tout les destinataires lors de la recherche du médecin addresseur d'un courrier.
+
+### Imports automatisés :
+- [#448](https://github.com/Refhi/Weda-Helper/issues/448) - Ignore désormais tout les noms trouvés après le mot-clé "destinataire(s)" dans le dernier tier du document lors de la recherche du médecin addresseur d'un courrier.
+- [#452](https://github.com/Refhi/Weda-Helper/issues/452) - Ignore désormais les lignes contenant plusieurs types d'examens (en général quand le centre d'imagerie annonce ses capacités d'examen).
 
 
 # [2.13] - Gel des demandes de fonctionnalités

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Si vous souhaitez voir le détail, cliquez sur les numéros qui vous renverrons 
 # [2.13.1] - Correctifs
 ## Fix :
 - [#465](https://github.com/Refhi/Weda-Helper/issues/465) - L'historique gauche est de nouveau affiché avec 30% de largeur par défaut au lieu des 50% proposé de base par Weda. (actif si l'historique gauche est activé automatiquement dans les consultations)
+- [#459](https://github.com/Refhi/Weda-Helper/issues/459) - Un bouton permet désormais de réinitialiser le classement automatique des documents dans les échanges sécurisés. Cela permet de tester plus facilement différents mots-clés de classification.
 
 
 # [2.13] - Gel des demandes de fonctionnalités

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Toutes les modifications notables de ce projet sont documentées dans ce fichier
 
 Si vous souhaitez voir le détail, cliquez sur les numéros qui vous renverrons vers les tickets correspondants.
 
+# [2.13.1] - Correctifs
+## Fix :
+- [#465](https://github.com/Refhi/Weda-Helper/issues/465) - L'historique gauche est de nouveau affiché avec 30% de largeur par défaut au lieu des 50% proposé de base par Weda. (actif si l'historique gauche est activé automatiquement dans les consultations)
+
+
 # [2.13] - Gel des demandes de fonctionnalités
 ## AnnonceS : (les détails de la mise à jour sont après)
 Sommaire :

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Si vous souhaitez voir le détail, cliquez sur les numéros qui vous renverrons 
 ## Fix :
 - [#465](https://github.com/Refhi/Weda-Helper/issues/465) - L'historique gauche est de nouveau affiché avec 30% de largeur par défaut au lieu des 50% proposé de base par Weda. (actif si l'historique gauche est activé automatiquement dans les consultations)
 - [#459](https://github.com/Refhi/Weda-Helper/issues/459) - Un bouton permet désormais de réinitialiser le classement automatique des documents dans les échanges sécurisés. Cela permet de tester plus facilement différents mots-clés de classification.
+- [#448](https://github.com/Refhi/Weda-Helper/issues/448) - Ignore désormais tout les destinataires lors de la recherche du médecin addresseur d'un courrier.
 
 
 # [2.13] - Gel des demandes de fonctionnalités

--- a/consultation.js
+++ b/consultation.js
@@ -518,16 +518,27 @@ addTweak('/FolderMedical/ConsultationForm.aspx', 'AutoOpenHistory_Consultation',
             actionFilter(elements[0].contentDocument);
         }
     });
+
+    // Réduction de la taille de l'historique (Weda propose une taille de 60% de la page)
+    waitForElement({
+        selector: '#ColumnHistorique',        
+        callback: function (elements) {
+            const historiqueElement = elements[0];
+            console.log('Historique element trouvé', historiqueElement);
+            historiqueElement.style.width = '30%'; // Réduire la taille de l'historique à 30% de la page
+        }
+    });
 });
 
 // // Définir les pages pour lesquelles l'historique doit être déplacé à gauche et leur cible
 let pagesToLeftPannel_ = [
-    {
-        url: '/FolderMedical/ConsultationForm.aspx',
-        targetElementSelector: '#form1 > div:nth-child(14) > div > table > tbody > tr > td:nth-child(1) > table',
-        option: 'MoveHistoriqueToLeft_Consultation',
-        pageType: 'Consultation'
-    },
+    // Depreciated car l'historique est maintenant géré par Weda pour les consultations
+    // {
+    //     url: '/FolderMedical/ConsultationForm.aspx',
+    //     targetElementSelector: '#form1 > div:nth-child(14) > div > table > tbody > tr > td:nth-child(1) > table',
+    //     option: 'MoveHistoriqueToLeft_Consultation',
+    //     pageType: 'Consultation'
+    // },
     {
         url: '/FolderMedical/CertificatForm.aspx',
         targetElementSelector: 'table[onmouseover="ForceCloseListBoxGlossaire();"] > tbody > tr',

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Weda Helper",
   "version": "2.13.1",
-  "version_name": "2.13.1-alpha1",
+  "version_name": "2.13.1",
   "options_page": "options.html",
   "permissions": [
     "storage"

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
   "name": "Weda Helper",
-  "version": "2.13",
-  "version_name": "2.13",
+  "version": "2.13.1",
+  "version_name": "2.13.1-alpha1",
   "options_page": "options.html",
   "permissions": [
     "storage"

--- a/pdfParser.js
+++ b/pdfParser.js
@@ -45,7 +45,7 @@ addTweak('/FolderMedical/UpLoaderForm.aspx', 'autoPdfParser', function () {
     });
 });
 
-// 2.b. Dans la page des Echanges Sécurisés TODO
+// 2.b. Dans la page des Echanges Sécurisés
 addTweak('/FolderMedical/WedaEchanges', 'autoPdfParser', function () {
     console.log('[pdfParser] Chargement de la page d\'échanges');
     waitForElement({
@@ -398,6 +398,12 @@ async function selectDocumentTypeES(documentType) {
  * Insère le titre au bon endroit pour les échanges sécurisés
  */
 async function setTitleIfNeededES(Titre) {
+    const titleOption = await getOptionPromise('PdfParserAutoTitle');
+    console.log("[pdfParser] setTitleIfNeededES avec titleOption", titleOption);
+    if (!titleOption) {
+        console.log("[pdfParser] Option PdfParserAutoTitle désactivée, pas de titre à mettre");
+        return;
+    }
     // Le champ de titre est l'input avec le titre "C'est le titre qu'aura le document dans le dossier patient"
     let titleInput = document.querySelectorAll("input[title=\"C'est le titre qu'aura le document dans le dossier patient\"]");
     // On sélectionne le dernier input (le plus bas dans le DOM)

--- a/pdfParser.js
+++ b/pdfParser.js
@@ -83,12 +83,37 @@ addTweak('/FolderMedical/WedaEchanges', 'autoPdfParser', function () {
                 searchField.style.left = "0";
                 searchField.style.width = "99%";
                 searchField.style.maxHeight = `${maxHeight}px`;
-                // searchField.style.zIndex = "9999"; // Assurez-vous que l'élément est au-dessus des autres
                 searchField.style.overflow = "auto"; // Ajoute un défilement si le contenu dépasse
                 console.log(`[pdfParser] Champ de recherche de patient décalé vers le bas de ${displacement}px avec une hauteur maximale de ${maxHeight}px`);
             }
         }
     });
+
+    // Et on ajoute un bouton pour réinitialiser les données d'analyse automatique du PDF
+    waitForElement({
+        selector: ".documentImport",
+        callback: function (elements) {
+            const mainDiv = elements[0];
+
+            if (mainDiv) {
+                const resetButton = document.createElement('button');
+                resetButton.innerText = '🔄 WH : Réinitialiser auto-imports';
+                resetButton.style.marginLeft = '10px';
+                resetButton.title = "Weda-Helper : Réinitialise les données d'analyse automatique du PDF. Utile lorsque vous testez différents mots-clés de classement automatique dans les options."; // Texte lors du survol de la souris
+                resetButton.type = 'button'; // Assure que c'est un bouton cliquable
+                resetButton.onclick = function () {
+                    sessionStorage.clear();
+                    console.log("[pdfParser] Toutes les données d'analyse automatique du PDF ont été réinitialisées.");
+                    sendWedaNotif({
+                        message: "Toutes les données d'analyse automatique du PDF ont été réinitialisées.",
+                        type: 'success'
+                    });
+                };
+                mainDiv.appendChild(resetButton);
+            }
+        }
+    });
+
 });
 
 

--- a/pdfParser.js
+++ b/pdfParser.js
@@ -1849,14 +1849,34 @@ function findSpecialite(fullText, specialites) {
 
 // Fonction pour trouver le type d'imagerie dans le texte
 function findImagerie(fullText, imageries) {
-    for (const [imagerie, keywords] of Object.entries(imageries)) {
-        for (const keyword of keywords) {
-            if (fullText.toLowerCase().includes(keyword.toLowerCase())) {
-                console.log('[pdfParser] type d\'imagerie trouvé', imagerie);
-                return imagerie;
+    const lines = fullText.split('\n');
+    
+    for (const line of lines) {
+        const lineText = line.toLowerCase();
+        let matchesInLine = [];
+        
+        // Compter combien de types d'imagerie matchent dans cette ligne
+        for (const [imagerie, keywords] of Object.entries(imageries)) {
+            for (const keyword of keywords) {
+                if (lineText.includes(keyword.toLowerCase())) {
+                    matchesInLine.push(imagerie);
+                    break; // Sortir de la boucle keywords pour cette imagerie
+                }
             }
         }
+        
+        // Si exactement un match dans cette ligne, c'est probablement le bon
+        if (matchesInLine.length === 1) {
+            console.log('[pdfParser] type d\'imagerie trouvé', matchesInLine[0], 'dans la ligne:', line.substring(0, 50) + '...');
+            return matchesInLine[0];
+        }
+        // Si plusieurs matches, on ignore cette ligne (probablement une liste de services)
+        else if (matchesInLine.length > 1) {
+            console.log('[pdfParser] Ligne ignorée (multiples types d\'imagerie):', line.substring(0, 50) + '...');
+        }
     }
+    
+    console.log('[pdfParser] Aucun type d\'imagerie trouvé dans une ligne unique');
     return null;
 }
 

--- a/pdfParser.js
+++ b/pdfParser.js
@@ -2037,6 +2037,12 @@ function determineDocumentTitle(fullText, documentType) {
         for (const third of thirds) {
             for (let i = third.start; i < third.end; i++) {
                 const line = lines[i];
+                
+                // Pour le dernier tiers (signature), ignorer tout après "destinataire" ou "destinataires"
+                if (third.name === 'signature' && /destinataires?/i.test(line)) {
+                    break;
+                }
+                
                 for (const pattern of doctorPatterns) {
                     const match = line.match(pattern);
                     if (match && match[1]) {

--- a/utils.js
+++ b/utils.js
@@ -697,6 +697,44 @@ chrome.runtime.onMessage.addListener(
     }
 );
 
+/**
+ * Envoie une notification Weda à tous les onglets en utilisant le stockage local de Chrome.
+ * Cette fonction stocke les options de notification avec un identifiant unique basé sur l'horodatage,
+ * ce qui déclenche ensuite l'affichage de la notification dans tous les onglets grâce au listener
+ * chrome.storage.onChanged.
+ * 
+ * @async
+ * @function sendWedaNotifAllTabs
+ * @param {Object} options - Les options de la notification à envoyer.
+ * @param {string} [options.message="Notification de test"] - Le message à afficher dans la notification.
+ * @param {string} [options.icon="home"] - L'icône Material Design à utiliser pour la notification.
+ * @param {string} [options.type="success"] - Le type de notification ('success', 'fail', ou undefined pour neutre).
+ * @param {string} [options.extra="{}"] - Données supplémentaires au format JSON.
+ * @param {number} [options.duration=5000] - Durée d'affichage de la notification en millisecondes.
+ * @param {Object} [options.action] - Action optionnelle à exécuter (ex: demande de permission).
+ * 
+ * @example
+ * // Envoi d'une notification simple
+ * const notifId = await sendWedaNotifAllTabs({
+ *     message: "Opération réussie",
+ *     type: "success",
+ *     duration: 3000
+ * });
+ * 
+ * @example
+ * // Envoi d'une notification avec gestion d'erreur
+ * try {
+ *     await sendWedaNotifAllTabs({
+ *         message: "Erreur lors du traitement",
+ *         type: "fail",
+ *         icon: "error"
+ *     });
+ * } catch (error) {
+ *     console.error('Échec de l\'envoi de la notification:', error);
+ * }
+ * 
+ * @see {@link sendWedaNotif} Pour envoyer une notification uniquement dans l'onglet actuel.
+ */
 async function sendWedaNotifAllTabs(options) {
     // Ajoute un identifiant unique basé sur l'horodatage actuel
     options.id = Date.now();


### PR DESCRIPTION
## Fix :
- [#465](https://github.com/Refhi/Weda-Helper/issues/465) - L'historique gauche est de nouveau affiché avec 30% de largeur par défaut au lieu des 50% proposé de base par Weda. (actif si l'historique gauche est activé automatiquement dans les consultations)
- [#459](https://github.com/Refhi/Weda-Helper/issues/459) - Un bouton permet désormais de réinitialiser le classement automatique des documents dans les échanges sécurisés. Cela permet de tester plus facilement différents mots-clés de classification.

### Imports automatisés :
- [#448](https://github.com/Refhi/Weda-Helper/issues/448) - Ignore désormais tout les noms trouvés après le mot-clé "destinataire(s)" dans le dernier tier du document lors de la recherche du médecin addresseur d'un courrier.
- [#452](https://github.com/Refhi/Weda-Helper/issues/452) - Ignore désormais les lignes contenant plusieurs types d'examens (en général quand le centre d'imagerie annonce ses capacités d'examen).
- [#464](https://github.com/Refhi/Weda-Helper/issues/464) - Prend en compte le décochage de l'option Titre Automatique (échanges sécurisés).
- [#464](https://github.com/Refhi/Weda-Helper/issues/464) - Amélioration des messages d'erreurs lors de l'import des échanges sécurisés.