### PR TITLE
Ajustement Regex du pdfParser

### DIFF
--- a/src/features/pdfParser.js
+++ b/src/features/pdfParser.js
@@ -1304,11 +1304,11 @@ async function extractLines(textItems) {
 async function extractRelevantData(fullText) {
     const regexPatterns = {
         dateRegexes: [
-            /[0-9]{2}[\/\-.][0-9]{2}[\/\-.][0-9]{4}/g, // Match dates dd/mm/yyyy ou dd-mm-yyyy
+            /(?!06\/01\/1978)[0-9]{2}[\/\-.][0-9]{2}[\/\-.][0-9]{4}/g, // Match dates dd/mm/yyyy ou dd-mm-yyyy sauf 06/01/1978
             /([0-9]{1,2})\s+(janvier|février|mars|avril|mai|juin|juillet|août|septembre|octobre|novembre|décembre)\s+([0-9]{4})/gi // Match dates comme "28 novembre 2024"
         ],
         dateOfBirthRegexes: [
-            /(?:né\(e\) le|date de naissance:|date de naissance :|née le)[\s\S]([0-9]{2}[\/\-.][0-9]{4})/gi // Match la date de naissance
+            /(?:né\(e\) le|date de naissance:|date de naissance :|née le|né le)[\s\S]([0-9]{2}[\/\-.][0-9]{4})/gi // Match la date de naissance
         ],
         nameRegexes: [
             /(?:Mme|Madame|Monsieur|M\.) (.*?)(?: \(| né| - né)/gi, // Match pour les courriers, typiquement "Mr. XXX né le"


### PR DESCRIPTION
- Amélioration du Regex de DDN (prends en compte "né le")
- Ajout d'une exception pour la date 06/01/1978 présente dans de nombreux courriers en raison de la loi informatique et liberté du 06/01/1978 et prise à tort pour la DDN

Ex: courriers du CHU de Toulouse mentionnent en fin de courrier systématiquement:  _Les données et/ou échantillons recueillis lors des venues des patients au CHU de Toulouse peuvent être réutilisés et/ou partagés à des fins de recherches et d'organisation
des soins. Afin de garantir la confidentialité de ces données, celles-ci seront codées. Conformément à la loi informatique et liberté du 06/01/1978 [...]_

A discuter sur l'implémentation, cela me semble plus simple d'exclure simplement cette date (pénalise uniquement le classement des courriers pour les éventuels patients né ce jour) plutôt que de rajouter un Regex qui exclus le 06/01/1978 si le texte autour évoque du texte juridique