### PR TITLE
Ajout d'un scrapping du lieu de la consultation

### DIFF
--- a/src/utils/dataScrapper.js
+++ b/src/utils/dataScrapper.js
@@ -69,6 +69,7 @@ const _DAILY = {
     mainContainer: usualMainContainer,
     subContainer:  usualSubContainer,
     date:      "[title='Cliquez sur la date pour ouvrir.']",
+    lieu:       "span[class='evelieu']", 
     author:    ".sign",
 };
 
@@ -1248,6 +1249,10 @@ function recoverMainViewData(doc, categorySelectors, includeLegacy = false, cate
 function parseDayContainer(container, categorySelectors) {
     // Extraction des métadonnées de la journée (header table)
     const dateElement = container.querySelector(categorySelectors.date);
+    const lieuElement = container.querySelector(categorySelectors.lieu);
+    const lieu = lieuElement?.textContent || '';
+    const date = dateElement.textContent.replace(lieu,'').trim(); // Si il y'a un lieu spécifié, on le retire de du texte de la date
+
     const initials = textOf(container, SELECTORS.dayContainer.initials);
 
     // Documents : tous les divs name="dhX" sauf dh10 (pièces jointes)
@@ -1291,7 +1296,8 @@ function parseDayContainer(container, categorySelectors) {
     documents.forEach(doc => { delete doc.author; delete doc.author_prenom; delete doc.author_nom; });
     
     return {
-        date: dateElement?.textContent.trim() || null,
+        date: date,
+        lieu: lieu,
         ...authorInfo,
         documents,
         attachments


### PR DESCRIPTION
Weda permet de spécifier le lieu de la consultaition (par défaut vide) 
<img width="1258" height="368" alt="Capture d&#39;écran 2026-07-28 153528" src="https://github.com/user-attachments/assets/ea7ac909-ab1d-41a9-ada9-d92e68299007" />

Cette PR ajoute la possibilité d'extraire le lieu avec le dataScrapper.

Utile notamment pour détecter une visite et proposer une cotation par défaut pour les visites.

N.B. le lieu est dans le conteneur de la date d'où l'extraction du lieu suivi du retrait du lieu si il a été trouvé du texte de la date