### PR TITLE
Changement de la méthode de déclenchement du pdfParser pour Echanges Securisés

### DIFF
--- a/src/features/pdfParser.js
+++ b/src/features/pdfParser.js
@@ -71,10 +71,16 @@ addTweak('/FolderMedical/UpLoaderForm.aspx', 'autoPdfParser', function () {
 addTweak('/FolderMedical/WedaEchanges', 'autoPdfParser', function () {
     console.log('[pdfParser] Chargement de la page d\'échanges');
     waitForElement({
-        // Ici on déclenche la procédure à la détection de la page de sélection du patient
-        selector: "#ContentPlaceHolder1_FindPatientUcForm1_DropDownListRechechePatient",
-        callback: function () {
-            processFoundPdfIframeEchanges(false);
+        // Ici on déclenche la procédure lors du clic sur le bouton "Un patient".
+        selector: ".importPatient",
+        callback: function (elements) {
+            elements.forEach(function (element) { //Ajout d'un listener sur tous les boutons "Un patient".
+                element.addEventListener("click", function () {
+                    console.log("[pdfParser] Importation du message cliqué, je vais traiter le PDF présent dans l'iframe.");
+                    setTimeout(() => processFoundPdfIframeEchanges(false), 500); //Délai pour permettre à la fenetre de recherche de s'afficher
+                    
+                });
+            });
         }
     });
 
@@ -337,7 +343,7 @@ async function processFoundPdfIframeEchanges(isINSValidated = false) {
             if (searchResult.needsPageRefresh) {
                 // Dans les échanges, on attend le changement DOM au lieu d'un refresh complet
                 console.log("[pdfParser] Echanges - Attente changement DOM :", searchResult.message);
-                await new Promise(resolve => setTimeout(resolve, 2000));
+                await new Promise(resolve => setTimeout(resolve, 500));
                 continue; // Nouvelle tentative
             }
 


### PR DESCRIPTION
Résous #641 
Le déclenchement de la procédure à la détection de la page de recherche de patient entrainait un appel en boucle de la procédure dans certaines situations.
La procédure se déclenche maintenant sur le clic du bouton Importer pour "un patient" avec un délai pour permettre à la fenetre de recherche de s'afficher.

A tester ++ car j'ai cru comprendre qu'il y'avait plusieurs versions différentes des Echanges Securisés (ex: de mon côté je n'ai jamais eu la fonctionnalité de classement automatique avec l'INS).
Aucun bug chez moi mais à voir avec d'autres versions.